### PR TITLE
Heredoc Ctrl+C Interactive Prompt Glitch Fixes

### DIFF
--- a/src/utils/run_minishell.c
+++ b/src/utils/run_minishell.c
@@ -6,7 +6,7 @@
 /*   By: mgodawat <mgodawat@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/11 00:35:07 by mgodawat          #+#    #+#             */
-/*   Updated: 2025/05/30 18:26:38 by mgodawat         ###   ########.fr       */
+/*   Updated: 2025/05/31 17:35:38 by mgodawat         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,13 +43,11 @@ static int	process_command(char *cmd, t_token **token_list, t_context *ctx)
 
     // If print_exec_list is available and DEBUG is defined, this is useful
     // Ensure print_exec_list is defined in a header included by run_minishell.c
-    #ifdef DEBUG 
     if (DEBUG && exec_list) {
          printf("--- AST Structure (in process_command) ---\n");
          print_exec_list(exec_list); // Make sure this function is declared/available
          printf("--- End AST Structure (in process_command) ---\n");
     }
-    #endif
 
 	if (!execute_pipeline(ctx))
 	{
@@ -112,7 +110,11 @@ static int	handle_command_input_cycle(t_context *ctx)
 
 	tokens = NULL;
 	if (isatty(STDIN_FILENO))
-		g_signal = 0;
+	{
+		// Revert the specific g_signal check and rl_* calls here.
+		// Responsibility is moved to read_heredoc_input.
+		g_signal = 0; // Reset for the upcoming readline call
+	}
 	cmd_line = read_cmd(ctx);
 	input_result = handle_input_cases(cmd_line, ctx);
 	if (input_result != 0)


### PR DESCRIPTION
When interrupting a heredoc input (e.g., `cat << EOF`) using Ctrl+C, several visual glitches occurred:
1.  Initially, after Ctrl+C, the new shell prompt would appear, but pressing Enter would unexpectedly restart the heredoc input (`heredoc>`).
2.  Subsequent fixes led to `^C\` appearing, with the new shell prompt on the same line.
3.  Further refinements caused a double shell prompt (`minishell → minishell →`) to appear after the interruption.

The core problem was ensuring `readline`'s state was correctly managed and reset after a SIGINT occurred during a manual `read()` loop (for heredoc) when `readline` itself was not the active input mechanism.

## Root Cause Analysis & Solutions Implemented

The issues stemmed from interactions between custom signal handlers, the main shell loop's signal handling, and `readline`'s internal state management.

1.  **Restarting Heredoc (Initial Problem):**
    *   **Cause:** Believed to be interference from the primary SIGINT handler (which calls `rl_*` functions like `rl_redisplay`) running when it shouldn't, or improper state reset for the next command input.
    *   **Solution Iteration 1:** A dedicated, minimal SIGINT handler (`heredoc_sigint_handler`) was introduced for the duration of `read_heredoc_input`. This handler initially only set `g_signal = SIGINT` and wrote a newline. The main shell loop in `run_minishell.c` was modified to call `rl_on_new_line()` and `rl_replace_line()` before `read_cmd()` if `g_signal` was set.

2.  **`^C\` and Prompt on Same Line:**
    *   **Cause:** The above solution helped but didn't fully clean `readline`'s perception of the line state. The `heredoc_sigint_handler` writing a newline wasn't enough for `readline` to always position the next prompt correctly, and stray characters (`\`) appeared.
    *   **Solution Iteration 2:** The `heredoc_sigint_handler` was simplified to *only* set `g_signal = SIGINT`. The logic in `read_heredoc_input`, upon detecting this `g_signal`, was made responsible for:
        1.  Restoring the original SIGINT handler.
        2.  Manually calling the full sequence: `write(STDOUT_FILENO, "\n", 1);`, `rl_replace_line("", 0);`, `rl_on_new_line();`, and `rl_redisplay();`.
        The corresponding logic in `run_minishell.c` to call `rl_on_new_line()` etc. was reverted.

3.  **Double Prompt (`minishell → minishell →`):**
    *   **Cause:** The `rl_redisplay()` call within `read_heredoc_input`'s SIGINT handling block was drawing the prompt. Then, the main shell loop's call to `readline()` (in `read_cmd`) would draw the prompt again.
    *   **Solution Iteration 3 (Final Fix):** The `rl_redisplay()` call was removed from the SIGINT handling block in `read_heredoc_input.c`. The sequence of `write(STDOUT_FILENO, "\n", 1);`, `rl_replace_line("", 0);`, and `rl_on_new_line();` was kept. This prepares `readline`'s state without prematurely drawing the prompt. The main loop's subsequent call to `readline()` then handles drawing the prompt once.

**File: `src/heredoc/hd_read_input.c` (Key changes in `read_heredoc_input`'s SIGINT block)**
```c
static void heredoc_sigint_handler(int sig)
{
    (void)sig;
    g_signal = SIGINT; // ONLY sets the flag
}

// Inside read_heredoc_input:
if (g_signal == SIGINT) 
{
    sigaction(SIGINT, &sa_old_int, NULL); // Restore original handler
    
    // Prepare readline state for the *next* prompt, do not redisplay here
    write(STDOUT_FILENO, "\n", 1);
    rl_replace_line("", 0); 
    rl_on_new_line(); 
    // rl_redisplay(); // <--- THIS WAS REMOVED
    
    return (handle_sigint_case_for_heredoc(line_read, ctx));
}
```

## Outcome

With these iterative refinements, interrupting a heredoc with Ctrl+C now correctly:
*   Terminates the heredoc input.
*   Prints a single newline.
*   Displays a single, clean `minishell → ` prompt on the new line.
*   The shell remains responsive and behaves as expected for subsequent commands.